### PR TITLE
Added `set -euf -o pipefail` to all the bash scripts

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 source "InstallerFiles/Utils.sh"
 
 noUpgrade=$1

--- a/InstallAdditions.sh
+++ b/InstallAdditions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 source "InstallerFiles/Utils.sh"
     
 function installCameraPatch()

--- a/InstallerFiles/AfterReboot.sh
+++ b/InstallerFiles/AfterReboot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 source "Utils.sh"
 
 addStartup "SmartifyOS" "$HOME/SmartifyOS/Scripts/StartSmartifyOS.sh"

--- a/InstallerFiles/Utils.sh
+++ b/InstallerFiles/Utils.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/SmartifyOS/AndroidAuto/fullscreen-app.sh
+++ b/SmartifyOS/AndroidAuto/fullscreen-app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 sleep $1
 
 WINDOW_ID=$(xdotool search --class $2)

--- a/SmartifyOS/AndroidAuto/start-android-auto.sh
+++ b/SmartifyOS/AndroidAuto/start-android-auto.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 ./fullscreen-app.sh 10 "desktop-head-unit" &
 
 #sudo apt install adb libc++1 libc++abi1

--- a/SmartifyOS/Scripts/AutoUpdate.sh
+++ b/SmartifyOS/Scripts/AutoUpdate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 UPDATE_PATH=$1
 
 if [ -z "$UPDATE_PATH" ]; then

--- a/SmartifyOS/Scripts/FindUpdatePath.sh
+++ b/SmartifyOS/Scripts/FindUpdatePath.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 usb_mount_points=$(mount | grep "^/dev/sd" | cut -d' ' -f3)
 
 for mount_point in $usb_mount_points; do

--- a/SmartifyOS/Scripts/SetNetworkServices.sh
+++ b/SmartifyOS/Scripts/SetNetworkServices.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 ENABLE=$1
 
 if [ -z "$ENABLE" ]; then

--- a/SmartifyOS/Scripts/StartAndroidAuto.sh
+++ b/SmartifyOS/Scripts/StartAndroidAuto.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 cd ~/SmartifyOs/AndroidAuto/ || exit
 
 tmux new-session -d -s aa_session './start-android-auto.sh'

--- a/SmartifyOS/Scripts/StartSmartifyOS.sh
+++ b/SmartifyOS/Scripts/StartSmartifyOS.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 cd "$HOME/SmartifyOS/GUI/" || exit
 
 nohup ./SmartifyOS.x86_64 &

--- a/SmartifyOS/Scripts/StartTouchInput.sh
+++ b/SmartifyOS/Scripts/StartTouchInput.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euf -o pipefail
+
 cd ~/SmartifyOS/Scripts/ || exit
 
 sudo python3 TouchInput.py


### PR DESCRIPTION
Shell scripts by default will only exit with a failing status code if the last command in them does so.

This means that if a command within the script fails, it may do so silently, leaving the user unaware of the failure until they encounter an issue later.

Using `set -euf -o pipefail` at the start of the script ensures that if a line in the script exits with a failing status code, the script will do so too (in most cases), making the failure obvious to the user.

A good guide for writing safe shell script can be found [here](https://sipb.mit.edu/doc/safe-shell/).

Using a linter such as [shell check](https://www.shellcheck.net/) may also be beneficial.